### PR TITLE
Fix typo and update README.rst to account for forking

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ The easiest way to install colormath2 is via pip::
 
 The development dependencies are installed as follows::
 
-    $ pip install 'colormath2[development]'
+    $ pip install -I -e .[development]
 
 Documentation
 -------------

--- a/README.rst
+++ b/README.rst
@@ -37,17 +37,19 @@ Requirements
 Installation
 ------------
 
-User Install
-^^^^^^^^^^^^
+Users
+^^^^^
 
 The easiest way to install colormath2 is via pip::
 
     $ pip install colormath2
 
-Developer Install
-^^^^^^^^^^^^^^^^^
+Contributors
+^^^^^^^^^^^^
 
-Install the development dependencies as follows::
+#. Fork and clone the repo
+#. Create a virtual environment
+#. Install the development dependencies as follows::
 
     $ pip install -I -e .[development]
 
@@ -56,8 +58,8 @@ Git and Line Endings
 
 This repo currently uses Windows-style line endings.
 
-If you see ``^M`` at the end of lines in your editor, try running
-the following on your local fork::
+If you see ``^M`` at the end of lines in your editor or ``git diff`` view,
+try running the following on your local clone::
 
     git config --local global.whitespace "cr-at-eol"
 

--- a/README.rst
+++ b/README.rst
@@ -30,9 +30,9 @@ color space conversions, Delta E, and density to spectral.
 Requirements
 ------------
 
-* numpy
-* NetworkX 2.0+
 * Python 3.8+
+* `numpy <https://numpy.org/>`_
+* `NetworkX <https://networkx.org/>`_ 2.0+
 
 Installation
 ------------

--- a/README.rst
+++ b/README.rst
@@ -65,12 +65,21 @@ the following on your local fork::
 Documentation
 -------------
 
-For documentation, see the project webpage at:
+For documentation, there are currently two main options:
 
-    http://python-colormath.readthedocs.org/
+.. list-table::
+   :header-rows: 0
 
-There are also a lot of useful examples under the examples directory within
-this directory.
+   * - This repo's `Examples directory`_
+     - Maintained example code for this library
+
+   * - The old `python-colormath docs`_
+     - Documentation for the original ``python-colormath``
+       module
+
+.. _Examples directory:: https://github.com/pushfoo/python-colormath2/tree/main/examples
+.. _python-colormath docs:: http://python-colormath.readthedocs.org/
+
 
 Support
 -------

--- a/README.rst
+++ b/README.rst
@@ -37,13 +37,30 @@ Requirements
 Installation
 ------------
 
+User Install
+^^^^^^^^^^^^
+
 The easiest way to install colormath2 is via pip::
 
     $ pip install colormath2
 
-The development dependencies are installed as follows::
+Developer Install
+^^^^^^^^^^^^^^^^^
+
+Install the development dependencies as follows::
 
     $ pip install -I -e .[development]
+
+Git and Line Endings
+====================
+
+This repo currently uses Windows-style line endings.
+
+If you see ``^M`` at the end of lines in your editor, try running
+the following on your local fork::
+
+    git config --local global.whitespace "cr-at-eol"
+
 
 Documentation
 -------------

--- a/README.rst
+++ b/README.rst
@@ -61,7 +61,7 @@ This repo currently uses Windows-style line endings.
 If you see ``^M`` at the end of lines in your editor or ``git diff`` view,
 try running the following on your local clone::
 
-    git config --local global.whitespace "cr-at-eol"
+    git config --local core.whitespace "cr-at-eol"
 
 
 Documentation

--- a/README.rst
+++ b/README.rst
@@ -73,12 +73,12 @@ For documentation, there are currently two main options:
    * - This repo's `Examples directory`_
      - Maintained example code for this library
 
-   * - The old `python-colormath docs`_
+   * - The `old python-colormath docs`_
      - Documentation for the original ``python-colormath``
        module
 
-.. _Examples directory:: https://github.com/pushfoo/python-colormath2/tree/main/examples
-.. _python-colormath docs:: http://python-colormath.readthedocs.org/
+.. _Examples directory: https://github.com/pushfoo/python-colormath2/tree/main/examples
+.. _old python-colormath docs: http://python-colormath.readthedocs.org/
 
 
 Support

--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ The easiest way to install colormath2 is via pip::
 
     $ pip install colormath2
 
-The development dependencies are installed as follows:
+The development dependencies are installed as follows::
 
     $ pip install 'colormath2[development]'
 


### PR DESCRIPTION
**TL;DR:** Fix missing `:` and clarify details

1. Fix the `:` breaking code display (fix the pic below)
![image](https://github.com/user-attachments/assets/90a25370-41bf-4324-b000-13c1d963a21b)
2. Add project links for dependencies and re-order them
3. Clarify the status of the old documentation for `python-colormath`